### PR TITLE
Candidates service

### DIFF
--- a/lib/jobvite_api.rb
+++ b/lib/jobvite_api.rb
@@ -1,2 +1,4 @@
 require 'jobvite_api/version'
 require 'jobvite_api/configuration'
+require 'jobvite_api/base'
+require 'jobvite_api/api/client'

--- a/lib/jobvite_api/api/client.rb
+++ b/lib/jobvite_api/api/client.rb
@@ -1,0 +1,32 @@
+module JobviteApi
+  class Client
+    include HTTMultiParty
+    include JobviteApi::Base
+    attr_accessor :api_key, :api_token
+    base_uri 'https://api.jobvite.com/api/v2'
+
+    def initialize(api_token = nil, api_key = nil)
+      @api_token = api_token || JobviteApi.configuration.api_token
+      @api_key = api_key || JobviteApi.configuration.api_key
+    end
+
+    def add_authentication_options(options)
+      options.merge(api: @api_key, sc: @api_token, format: 'json')
+    end
+
+    def candidates(id = nil, options = { start: 0, count: 500 })
+      options[:candidateId] = id unless id.nil?
+      response = get_from_jobvite_api '/candidate', options
+      response[:candidates]
+    end
+
+    def get_from_jobvite_api(url, options = {})
+      response = get_response(url, query: add_authentication_options(options))
+      if response.code == 200
+        parse_json(response)
+      else
+        raise StandardError.new(response.code)
+      end
+    end
+  end
+end

--- a/lib/jobvite_api/base.rb
+++ b/lib/jobvite_api/base.rb
@@ -1,0 +1,16 @@
+module JobviteApi
+  module Base
+    def get_response(url, options)
+      self.class.get(url, options)
+    end
+
+    def post_response(url, options)
+      self.class.post(url, options)
+    end
+
+    def parse_json(response)
+      MultiJson.load(response.body, symbolize_keys:
+        JobviteApi.configuration.symbolize_keys)
+    end
+  end
+end

--- a/spec/fixtures/cassettes/client/candidates.yml
+++ b/spec/fixtures/cassettes/client/candidates.yml
@@ -1,0 +1,64 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.jobvite.com/api/v2/candidate?api=example_api_key&count=5&format=json&sc=example_api_token&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - private, no-cache, no-store, max-age=0
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '21018'
+      Date:
+      - Fri, 13 Nov 2015 19:23:43 GMT
+      Server:
+      - Jobvite
+    body:
+      encoding: UTF-8
+      string: '{"candidates":[
+        {"address":"","address2":"","application":{"comments":null,"customField":[],"disposition":"Mandatory
+        Please Select One","eId":"pHdp0fw3","gender":"Undefined","hireDate":null,"job":{"company":null,"customField":null,"department":null,"eId":null,"hiringManagers":null,"jobType":null,"location":null,"recruiters":null,"requisitionId":null,"subsidiaryId":null,"title":null},"lastUpdatedDate":1264463700003,"race":"Decline
+        to Self Identify","resume":{"content":"","format":"Text"},"sentDate":1264463700003,"source":"John
+        Doe","sourceType":"Hiring Manager","startDate":null,"status":null,"veteranStatus":"Undefined","workflowState":"Rejected"},"city":"","companyName":null,"country":"USA","eId":"enXcZfwf","email":"","firstName":"John","homePhone":"","lastName":"Doe","location":",  United
+        States","postalCode":"","state":"","title":null,"workPhone":"","workStatus":"None"},
+        {"address":"","address2":"","application":{"comments":null,"customField":[],"disposition":"Mandatory
+        Please Select One","eId":"pHdp0fw3","gender":"Undefined","hireDate":null,"job":{"company":null,"customField":null,"department":null,"eId":null,"hiringManagers":null,"jobType":null,"location":null,"recruiters":null,"requisitionId":null,"subsidiaryId":null,"title":null},"lastUpdatedDate":1264463700003,"race":"Decline
+        to Self Identify","resume":{"content":"","format":"Text"},"sentDate":1264463700003,"source":"John
+        Doe","sourceType":"Hiring Manager","startDate":null,"status":null,"veteranStatus":"Undefined","workflowState":"Rejected"},"city":"","companyName":null,"country":"USA","eId":"enXcZfwf","email":"","firstName":"John","homePhone":"","lastName":"Doe","location":",  United
+        States","postalCode":"","state":"","title":null,"workPhone":"","workStatus":"None"},
+        {"address":"","address2":"","application":{"comments":null,"customField":[],"disposition":"Mandatory
+        Please Select One","eId":"pHdp0fw3","gender":"Undefined","hireDate":null,"job":{"company":null,"customField":null,"department":null,"eId":null,"hiringManagers":null,"jobType":null,"location":null,"recruiters":null,"requisitionId":null,"subsidiaryId":null,"title":null},"lastUpdatedDate":1264463700003,"race":"Decline
+        to Self Identify","resume":{"content":"","format":"Text"},"sentDate":1264463700003,"source":"John
+        Doe","sourceType":"Hiring Manager","startDate":null,"status":null,"veteranStatus":"Undefined","workflowState":"Rejected"},"city":"","companyName":null,"country":"USA","eId":"enXcZfwf","email":"","firstName":"John","homePhone":"","lastName":"Doe","location":",  United
+        States","postalCode":"","state":"","title":null,"workPhone":"","workStatus":"None"},
+        {"address":"","address2":"","application":{"comments":null,"customField":[],"disposition":"Mandatory
+        Please Select One","eId":"pHdp0fw3","gender":"Undefined","hireDate":null,"job":{"company":null,"customField":null,"department":null,"eId":null,"hiringManagers":null,"jobType":null,"location":null,"recruiters":null,"requisitionId":null,"subsidiaryId":null,"title":null},"lastUpdatedDate":1264463700003,"race":"Decline
+        to Self Identify","resume":{"content":"","format":"Text"},"sentDate":1264463700003,"source":"John
+        Doe","sourceType":"Hiring Manager","startDate":null,"status":null,"veteranStatus":"Undefined","workflowState":"Rejected"},"city":"","companyName":null,"country":"USA","eId":"enXcZfwf","email":"","firstName":"John","homePhone":"","lastName":"Doe","location":",  United
+        States","postalCode":"","state":"","title":null,"workPhone":"","workStatus":"None"},
+        {"address":"","address2":"","application":{"comments":null,"customField":[],"disposition":"Mandatory
+        Please Select One","eId":"pHdp0fw3","gender":"Undefined","hireDate":null,"job":{"company":null,"customField":null,"department":null,"eId":null,"hiringManagers":null,"jobType":null,"location":null,"recruiters":null,"requisitionId":null,"subsidiaryId":null,"title":null},"lastUpdatedDate":1264463700003,"race":"Decline
+        to Self Identify","resume":{"content":"","format":"Text"},"sentDate":1264463700003,"source":"John
+        Doe","sourceType":"Hiring Manager","startDate":null,"status":null,"veteranStatus":"Undefined","workflowState":"Rejected"},"city":"","companyName":null,"country":"USA","eId":"enXcZfwf","email":"","firstName":"John","homePhone":"","lastName":"Doe","location":",  United
+        States","postalCode":"","state":"","title":null,"workPhone":"","workStatus":"None"}
+        ],"total":238346,"status":{"code":200,"messages":[]}}'
+    http_version:
+  recorded_at: Fri, 13 Nov 2015 19:23:43 GMT
+recorded_with: VCR 2.5.0

--- a/spec/jobvite_api/api/client_spec.rb
+++ b/spec/jobvite_api/api/client_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe JobviteApi::Client do
+  before do
+    JobviteApi.configure do |config|
+      config.symbolize_keys = true
+    end
+    @client = JobviteApi::Client.new('example_api_token', 'example_api_key')
+  end
+  describe '#candidates' do
+    context 'given no id' do
+      before do
+        VCR.use_cassette('client/candidates') do
+          @candidates_response = @client.candidates(nil, start: 0, count: 5)
+        end
+      end
+
+      it 'returns a response' do
+        expect(@candidates_response).to_not be_nil
+      end
+
+      it 'returns an array of candidates' do
+        expect(@candidates_response).to be_an_instance_of(Array)
+      end
+
+      it 'returns details of candidates' do
+        expect(@candidates_response.first).to have_key(:firstName)
+      end
+    end
+  end
+end

--- a/spec/jobvite_api/configuration_spec.rb
+++ b/spec/jobvite_api/configuration_spec.rb
@@ -3,9 +3,11 @@ require 'spec_helper'
 describe JobviteApi::Configuration do
   after { restore_default_config }
 
-  context 'when no symbolize_keys is specified' do
+  context 'when given a false symbolize_keys value' do
     before do
-      restore_default_config
+      JobviteApi.configure do |config|
+        config.symbolize_keys = false
+      end
     end
 
     it 'returns the default value' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,8 @@ require 'rubygems'
 require 'bundler'
 require 'webmock/rspec'
 require 'vcr'
+require 'httmultiparty'
+require 'multi_json'
 require 'jobvite_api'
 
 require 'coveralls'
@@ -14,9 +16,13 @@ end
 VCR.configure do |config|
   config.cassette_library_dir = 'spec/fixtures/cassettes'
   config.hook_into :webmock
+  config.before_record do |i|
+    i.response.body.force_encoding('UTF-8')
+  end
 end
 
 def restore_default_config
   JobviteApi.configuration = nil
   JobviteApi.configure {}
+  JobviteApi.configuration.symbolize_keys = true
 end


### PR DESCRIPTION
Set up the api client and base url. Implementation
of the candidate service to get a list of candidates
that have been registered.
The call gets a list of options that are the start index
and the count which is the amount of candidates we want
the API to return
