### PR TITLE
Pagination of applicants/candidates

### DIFF
--- a/lib/jobvite_api/api/client.rb
+++ b/lib/jobvite_api/api/client.rb
@@ -14,7 +14,11 @@ module JobviteApi
       options.merge(api: @api_key, sc: @api_token, format: 'json')
     end
 
-    def candidates(id = nil, options = { start: 0, count: 500 })
+    def candidates(id = nil, options = { page: 1, per_page: 500 })
+      page = options.delete(:page)
+      per_page = options.delete(:per_page)
+      options[:start] = (page - 1) * per_page
+      options[:count] = per_page
       options[:candidateId] = id unless id.nil?
       response = get_from_jobvite_api '/candidate', options
       response[:candidates]

--- a/spec/jobvite_api/api/client_spec.rb
+++ b/spec/jobvite_api/api/client_spec.rb
@@ -11,7 +11,7 @@ describe JobviteApi::Client do
     context 'given no id' do
       before do
         VCR.use_cassette('client/candidates') do
-          @candidates_response = @client.candidates(nil, start: 0, count: 5)
+          @candidates_response = @client.candidates(nil, page: 1, per_page: 5)
         end
       end
 


### PR DESCRIPTION
Pagination of applicants/candidates

Now the candidates function will look for a key page and per_page
and return the correct page of results.

The reason for this change is to implement it the way our analytics expect 
the client to work. 
