### PR TITLE
Remove multi_json dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 /pkg/
 /spec/reports/
 /tmp/
+*.un~
+*.swp
+tags

--- a/jobvite_api.gemspec
+++ b/jobvite_api.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency('httmultiparty')
-  spec.add_dependency('multi_json', '>= 1.9.2', '<= 1.10.1')
   spec.required_ruby_version = '>= 1.9.3'
 
   spec.add_development_dependency 'bundler', '~> 1.9'

--- a/lib/jobvite_api/base.rb
+++ b/lib/jobvite_api/base.rb
@@ -9,7 +9,7 @@ module JobviteApi
     end
 
     def parse_json(response)
-      MultiJson.load(response.body, symbolize_keys:
+      JSON.parse(response.body, symbolize_names:
         JobviteApi.configuration.symbolize_keys)
     end
   end

--- a/lib/jobvite_api/version.rb
+++ b/lib/jobvite_api/version.rb
@@ -1,3 +1,3 @@
 module JobviteApi
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,6 @@ require 'bundler'
 require 'webmock/rspec'
 require 'vcr'
 require 'httmultiparty'
-require 'multi_json'
 require 'jobvite_api'
 
 require 'coveralls'


### PR DESCRIPTION
Ruby provides support to parse JSON data, so there is no need of this gem.
